### PR TITLE
Require rapidez 3.0 instead of 2.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "php": "^8.0|^8.1|^8.2",
         "guzzlehttp/guzzle": "^7.2",
         "illuminate/support": "^9.0|^10.0|^11.0",
-        "rapidez/core": "^2.8"
+        "rapidez/core": "^3.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
Seems like we missed the updated Rapidez requirement